### PR TITLE
chore: fix eslint config setup 

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,36 +1,32 @@
-import nodePlugin from 'eslint-plugin-n'
 import pluginSecurity from 'eslint-plugin-security'
-import neostandard, { resolveIgnoresFromGitignore } from 'neostandard'
+import neostandard, { resolveIgnoresFromGitignore, plugins } from 'neostandard'
 
-export default neostandard(
+export default [
+  ...neostandard({ ignores: resolveIgnoresFromGitignore() }),
+  plugins.n.configs['flat/recommended-script'],
+  pluginSecurity.configs.recommended,
   {
-    ignores: resolveIgnoresFromGitignore(),
-  },
-  [
-    nodePlugin.configs['flat/recommended-script'],
-    pluginSecurity.configs.recommended,
-    {
-      rules: {
-        'no-process-exit': 'warn',
-        'node/no-unsupported-features': 'off',
-        'node/no-unpublished-require': 'off',
-        'security/detect-non-literal-fs-filename': 'error',
-        'security/detect-unsafe-regex': 'error',
-        'security/detect-buffer-noassert': 'error',
-        'security/detect-child-process': 'error',
-        'security/detect-disable-mustache-escape': 'error',
-        'security/detect-eval-with-expression': 'error',
-        'security/detect-no-csrf-before-method-override': 'error',
-        'security/detect-non-literal-regexp': 'error',
-        'security/detect-object-injection': 'warn',
-        'security/detect-possible-timing-attacks': 'error',
-        'security/detect-pseudoRandomBytes': 'error',
-        'space-before-function-paren': 'off',
-        'object-curly-spacing': 'off',
-      },
-      languageOptions: {
-        ecmaVersion: 2024,
-        sourceType: 'module',
-      },
+    rules: {
+      'no-process-exit': 'warn',
+      'node/no-unsupported-features': 'off',
+      'node/no-unpublished-require': 'off',
+      'security/detect-non-literal-fs-filename': 'error',
+      'security/detect-unsafe-regex': 'error',
+      'security/detect-buffer-noassert': 'error',
+      'security/detect-child-process': 'error',
+      'security/detect-disable-mustache-escape': 'error',
+      'security/detect-eval-with-expression': 'error',
+      'security/detect-no-csrf-before-method-override': 'error',
+      'security/detect-non-literal-regexp': 'error',
+      'security/detect-object-injection': 'warn',
+      'security/detect-possible-timing-attacks': 'error',
+      'security/detect-pseudoRandomBytes': 'error',
+      'space-before-function-paren': 'off',
+      'object-curly-spacing': 'off',
     },
-  ])
+    languageOptions: {
+      ecmaVersion: 2024,
+      sourceType: 'module',
+    },
+  },
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@types/node": "^22.0.0",
         "c8": "^10.1.2",
         "eslint": "^9.6.0",
-        "eslint-plugin-n": "^17.9.0",
         "eslint-plugin-security": "^3.0.1",
         "husky": "^9.0.11",
         "lint-staged": "^15.2.7",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "@types/node": "^22.0.0",
     "c8": "^10.1.2",
     "eslint": "^9.6.0",
-    "eslint-plugin-n": "^17.9.0",
     "eslint-plugin-security": "^3.0.1",
     "husky": "^9.0.11",
     "lint-staged": "^15.2.7",


### PR DESCRIPTION
## Description

When researching repos that would be good candidates for canary tests (https://github.com/neostandard/neostandard/pull/85) I noticed that this eslint config was a bit erroneously setup.

This fixes that by:

* Moving to a top level array and spreading the neostandard config into it
* Making use of the exported `eslint-plugin-n` from neostandard (see https://github.com/neostandard/neostandard#exported-plugins)

You can inspect that all rules are included and apply as intended by running the ESLint inspector:

```sh
npx eslint --inspect-config
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
